### PR TITLE
Fix segfaults for string properties

### DIFF
--- a/src/mpv_enums.rs
+++ b/src/mpv_enums.rs
@@ -302,6 +302,12 @@ impl<'a> MpvFormat for &'a str {
     fn get_from_c_void<F : FnMut(*mut c_void)>(mut f:F) -> &'a str {
         let mut char_ptr = ptr::null_mut() as *mut c_void;
         f(&mut char_ptr as *mut *mut c_void as *mut c_void);
+        if char_ptr.is_null() {
+            // if this is still a nullptr (like, in an error)
+            // the code below will segfault
+            // since it runs *before* checking for an mpv error
+            return "";
+        }
         let return_str = unsafe {
             CStr::from_ptr(char_ptr as *mut c_char)
                  .to_str()
@@ -328,6 +334,12 @@ impl<'a> MpvFormat for OsdString<'a> {
     fn get_from_c_void<F : FnMut(*mut c_void)>(mut f:F) -> OsdString<'a> {
         let mut char_ptr = ptr::null_mut() as *mut c_void;
         f(&mut char_ptr as *mut *mut c_void as *mut c_void);
+        if char_ptr.is_null() {
+            // if this is still a nullptr (like, in an error)
+            // the code below will segfault
+            // since it runs *before* checking for an mpv error
+            return OsdString{string:""};
+        }
         let return_str = unsafe {
             CStr::from_ptr(char_ptr as *mut c_char)
                  .to_str()


### PR DESCRIPTION
Example program:

```rust
fn main() {
    let mut builder = mpv::MpvHandlerBuilder::new().unwrap();
    let mut mpv = builder.build().unwrap();

    mpv.get_property::<&str>("fkasdfkdms").unwrap();
}
```

Current behavior with mpv-rs 0.2.3:
```text
[1]    20326 segmentation fault (core dumped)  cargo run
```

Fixed (correct) behavior with this PR:
```text
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: MPV_ERROR_PROPERTY_NOT_FOUND', /checkout/src/libcore/result.rs:906:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cobrand/mpv-rs/4)
<!-- Reviewable:end -->
