### PR TITLE
Fix string use-after-free

### DIFF
--- a/src/mpv_enums.rs
+++ b/src/mpv_enums.rs
@@ -302,6 +302,12 @@ impl<'a> MpvFormat for &'a str {
     fn get_from_c_void<F : FnMut(*mut c_void)>(mut f:F) -> &'a str {
         let mut char_ptr = ptr::null_mut() as *mut c_void;
         f(&mut char_ptr as *mut *mut c_void as *mut c_void);
+        if char_ptr.is_null() {
+            // if this is still a nullptr (like, in an error)
+            // the code below will segfault
+            // since it runs *before* checking for an mpv error
+            return "";
+        }
         let return_str = unsafe {
             CStr::from_ptr(char_ptr as *mut c_char)
                  .to_str()
@@ -328,6 +334,12 @@ impl<'a> MpvFormat for OsdString<'a> {
     fn get_from_c_void<F : FnMut(*mut c_void)>(mut f:F) -> OsdString<'a> {
         let mut char_ptr = ptr::null_mut() as *mut c_void;
         f(&mut char_ptr as *mut *mut c_void as *mut c_void);
+        if char_ptr.is_null() {
+            // if this is still a nullptr (like, in an error)
+            // the code below will segfault
+            // since it runs *before* checking for an mpv error
+            return OsdString{string:""};
+        }
         let return_str = unsafe {
             CStr::from_ptr(char_ptr as *mut c_char)
                  .to_str()

--- a/src/mpv_handler.rs
+++ b/src/mpv_handler.rs
@@ -91,7 +91,7 @@ impl MpvHandlerBuilder {
     ///
     /// If it is available, the playing will try hardware decoding
     pub fn try_hardware_decoding(&mut self) -> Result<()> {
-        self.set_option("hwdec","auto")
+        self.set_option("hwdec","auto".to_string())
     }
 
     ///
@@ -127,7 +127,7 @@ impl MpvHandlerBuilder {
     pub fn build_with_gl(mut self,
                          get_proc_address: mpv_opengl_cb_get_proc_address_fn,
                          get_proc_address_ctx: *mut ::std::os::raw::c_void) -> Result<Box<MpvHandlerWithGl>> {
-        self.set_option("vo", "opengl-cb").expect("Error setting vo option to opengl-cb");
+        self.set_option("vo", "opengl-cb".to_string()).expect("Error setting vo option to opengl-cb");
         let mpv_handler_result = self.build();
         match mpv_handler_result {
             Ok(mpv_handler) => {
@@ -260,11 +260,14 @@ impl MpvHandler {
         let mut ret = 0 ;
         let format = T::get_mpv_format();
         let result = T::get_from_c_void(|ptr:*mut c_void|{
-            ret = unsafe {
-                mpv_get_property(self.handle,
-                                 ffi::CString::new(property).unwrap().as_ptr(),
-                                 format,
-                                 ptr)
+            let property = ffi::CString::new(property).unwrap();
+            {
+                ret = unsafe {
+                    mpv_get_property(self.handle,
+                                     property.as_ptr(),
+                                     format,
+                                     ptr)
+                }
             }
         });
         ret_to_result(ret,result)

--- a/src/mpv_handler.rs
+++ b/src/mpv_handler.rs
@@ -350,7 +350,7 @@ impl MpvHandler {
     ///
     /// Will panic if a null pointer is received from the libmpv API (should never happen)
 
-    pub fn wait_event<'a>(&mut self,timeout:f64) -> Option<Event<'a>> {
+    pub fn wait_event<'a>(&mut self,timeout:f64) -> Option<Event> {
         let event = unsafe {
             let ptr = mpv_wait_event(self.handle, timeout);
             if ptr.is_null() {

--- a/src/mpv_types.rs
+++ b/src/mpv_types.rs
@@ -1,4 +1,4 @@
 
-pub struct OsdString<'a> {
-    pub string:&'a str
+pub struct OsdString {
+    pub string: String
 }


### PR DESCRIPTION
Snippet of example code:

```rust
let count: i64 = mpv.get_property("metadata/list/count")?;
println!("Retrieving {} properties", count);
for i in 0..count {
    let key = mpv.get_property::<&str>(&format!("metadata/list/{}/key", i))?;
    let value = mpv.get_property::<&str>(&format!("metadata/list/{}/value", i))?;
    println!("key:'{}', value:'{}'", key, value);
}
```

which resulted in strange errors:

```
key:'forev', value:'foreverrr'
key:'mc chr', value:'mc chris'
```
([full metadata list example](https://gist.github.com/zekesonxx/bd1fed72f1d2e20ca7a6b7382c775abf))

and bloody confusing gdb printouts (breakpoint on the println line):

```
(gdb) print key
$1 = &str {data_ptr: 0x7fffdf0323b0 "foreverrr\000", length: 5}
(gdb) print value
$2 = &str {data_ptr: 0x7fffdf032270 "foreverrr\000", length: 9}
```

----

Some debugging later, I've discovered the original code goes something like:

1. Pass `char_ptr` (a nullptr) to libmpv
2. Call libmpv, `char_ptr` is now pointing to libmpv-allocated memory
3. Pass `char_ptr` into `CStr`, the new `CStr` points to libmpv-allocated memory
4. Call `to_str` on the `CStr`, the new `&str` points to libmpv-allocated memory
5. Call `mpv_free(char_ptr)`, mpv frees the memory, except we still have a pointer to it.
6. Return the `&str` to whoever is calling mpv-rs, which now points to freed memory (big no-no)

Obviously, that's really not okay. This changes `&str` to a `String`, and changes `OsdString(&str)` to `OsdString(String)`. That way we (Rust) own it, and are safe to tell mpv to free the memory it gave us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cobrand/mpv-rs/5)
<!-- Reviewable:end -->
